### PR TITLE
Add support for auto-merge configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ jobs:
           SQUASH_MERGE: 'true'
           MERGE_COMMIT: 'true'
           REBASE_MERGE: 'true'
+          AUTO_MERGE: 'false'
           DELETE_HEAD: 'false'
           BRANCH_PROTECTION_NAME: 'master'
           BRANCH_PROTECTION_REQUIRED_REVIEWERS: '1'
@@ -60,6 +61,7 @@ jobs:
 | SQUASH_MERGE | false | true | Whether or not to allow squash merges on the repo |
 | MERGE_COMMIT | false | true | Whether or not to allow merge commits on the repo |
 | REBASE_MERGE | false | true | Whether or not to allow rebase merges on the repo |
+| AUTO_MERGE | false | false | Whether or not to allow auto-merge on the repo |
 | DELETE_HEAD | false | false | Whether or not to delete head branch after merges |
 | BRANCH_PROTECTION_NAME | false | 'master' | Branch name pattern for branch protection rule |
 | BRANCH_PROTECTION_REQUIRED_REVIEWERS | false | 1 | Number of required reviewers for branch protection rule |

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Whether or not to allow rebase merges on the repo'
     required: false
     default: 'true'
+  AUTO_MERGE:
+    description: 'Whether or not to allow auto-merge on the repo'
+    required: false
+    default: 'false'
   DELETE_HEAD:
     description: 'Whether or not to delete head branch after merges'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ MERGE_COMMIT=$INPUT_MERGE_COMMIT
 echo "Merge Commit           : $MERGE_COMMIT"
 REBASE_MERGE=$INPUT_REBASE_MERGE
 echo "Rebase Merge           : $REBASE_MERGE"
+AUTO_MERGE=$INPUT_AUTO_MERGE
+echo "Auto-Merge             : $AUTO_MERGE"
 DELETE_HEAD=$INPUT_DELETE_HEAD
 echo "Delete Head            : $DELETE_HEAD"
 BRANCH_PROTECTION_NAME=$INPUT_BRANCH_PROTECTION_NAME
@@ -90,6 +92,7 @@ for repository in "${REPOSITORIES[@]}"; do
     --argjson squashMerge $SQUASH_MERGE \
     --argjson mergeCommit $MERGE_COMMIT \
     --argjson rebaseMerge $REBASE_MERGE \
+    --argjson autoMerge $AUTO_MERGE \
     --argjson deleteHead $DELETE_HEAD \
     '{
         has_issues:$allowIssues,
@@ -98,6 +101,7 @@ for repository in "${REPOSITORIES[@]}"; do
         allow_squash_merge:$squashMerge,
         allow_merge_commit:$mergeCommit,
         allow_rebase_merge:$rebaseMerge,
+        allow_auto_merge:$autoMerge,
         delete_branch_on_merge:$deleteHead,
     }' \
     | curl -d @- \


### PR DESCRIPTION
Adds support for [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) configuration.

The [update a repository endpoint](https://docs.github.com/en/rest/reference/repos#update-a-repository) has been updated to accept a `allow_auto_merge` parameter, which this PR uses.