### PR TITLE
Add unchanged option for branch protection rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
           REBASE_MERGE: 'true'
           AUTO_MERGE: 'false'
           DELETE_HEAD: 'false'
-          BRANCH_PROTECTION_ENABLED: true
+          BRANCH_PROTECTION_ENABLED: 'true'
           BRANCH_PROTECTION_NAME: 'main'
           BRANCH_PROTECTION_REQUIRED_REVIEWERS: '1'
           BRANCH_PROTECTION_DISMISS: 'true'
@@ -64,7 +64,7 @@ jobs:
 | REBASE_MERGE | false | true | Whether or not to allow rebase merges on the repo |
 | AUTO_MERGE | false | false | Whether or not to allow auto-merge on the repo |
 | DELETE_HEAD | false | false | Whether or not to delete head branch after merges |
-| BRANCH_PROTECTION_ENABLED | false | false | Whether or not to enable branch protection |
+| BRANCH_PROTECTION_ENABLED | false | false | Whether or not to enable branch protection. 'true' will overwrite any existing rules, while 'false' will remove branch protection rules. Use 'UNCHANGED' to avoid changing rules. |
 | BRANCH_PROTECTION_NAME | false | 'master' | Branch name pattern for branch protection rule |
 | BRANCH_PROTECTION_REQUIRED_REVIEWERS | false | 1 | Number of required reviewers for branch protection rule |
 | BRANCH_PROTECTION_DISMISS | false | true | Dismiss stale pull request approvals when new commits are pushed |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,7 +142,7 @@ for repository in "${REPOSITORIES[@]}"; do
             -u ${USERNAME}:${GITHUB_TOKEN} \
             --silent \
             ${GITHUB_API_URL}/repos/${repository}/branches/${BRANCH_PROTECTION_NAME}/protection
-    else
+    elif [ "$BRANCH_PROTECTION_ENABLED" == "false" ]; then
         curl \
             -X DELETE \
             -H "Accept: application/vnd.github.luke-cage-preview+json" \


### PR DESCRIPTION
The way BRANCH_PROTECTION_ENABLED is implemented it's not possible to make github-action-repo-settings-sync neutral about branch protection.

This PR requires BRANCH_PROTECTION_ENABLED to explicitly be set to 'false' to delete branch protection rules. Other strings, such as 'UNCHANGED' will result in github-action-repo-settings-sync not touching the branch protection rules.